### PR TITLE
umd: sync taskQueue operations in Emulator using condition variables

### DIFF
--- a/umd/core/src/runtime/include/priv/Emulator.h
+++ b/umd/core/src/runtime/include/priv/Emulator.h
@@ -30,6 +30,8 @@
 #define NVDLA_PRIV_EMULATOR_H
 
 #include <queue>
+#include <mutex>
+#include <condition_variable>
 
 #include "priv/EMUInterface.h"
 
@@ -78,6 +80,9 @@ private:
     bool m_threadActive;
 
     bool m_signalShutdown;
+
+    std::mutex m_mtx;
+    std::condition_variable m_cv;
 };
 
 } // nvdla::priv


### PR DESCRIPTION
We had a synchronisation problem with the Emulator threads on our VP. 
The first thread waits for 500ms until a task is pushed into the taskQueue. The second thread pushes a task in the taskQueue and waits until the first thread has processed the task using 'sched_yield'.
Because the first thread is still waiting (500ms), the scheduler repeatedly switches to the second thread, which yields its computation time.  
Due to that the 500ms are simulated very slowly on our VP. 

We synchronised the two threads using condition variables, such that the seconds thread notifies the first thread if he has pushed a task in the taskQueue and the first thread notifies the second one if he has processed the task. Both threads are also sensitive to the shutdown signal.  
