### PR TITLE
fix py3 syntax err

### DIFF
--- a/umd/utils/calibdata/calib_txt_to_json.py
+++ b/umd/utils/calibdata/calib_txt_to_json.py
@@ -54,7 +54,7 @@ def dump_json(json_root, json_file):
     logging.info("calibration output json: %s" % (json_file,))
     json_str = json.dumps(json_root, indent=4)
     with open(json_file, 'w') as fp:
-        fp.write(json_str);
+        fp.write(json_str)
         logging.debug(json_str)
 
 if __name__ == "__main__":
@@ -63,8 +63,8 @@ if __name__ == "__main__":
                 level=logging.INFO)
                 #level=logging.DEBUG)
     if len(sys.argv) != 3:
-        print "usage: calib_txt_to_json.py input_calib_txt output_calib_json"
-        exit(1);
+        print("usage: calib_txt_to_json.py input_calib_txt output_calib_json")
+        exit(1)
     calib_file = sys.argv[1]
     json_file = sys.argv[2]
     json_data = read_calibtable_txt2json(calib_file)


### PR DESCRIPTION
It is explicitly pointed out here that we use python3
#!/usr/bin/env python3
but there were some python2 style code which is not supported by python3，and some special symbol ;
i do remove all symbol ; and fix a print function call methods to mate python3.